### PR TITLE
Implement test creation and update

### DIFF
--- a/src/app/(ui)/(pages)/admin-dashboard/tests/page.tsx
+++ b/src/app/(ui)/(pages)/admin-dashboard/tests/page.tsx
@@ -9,6 +9,7 @@ import { FiEdit } from "react-icons/fi";
 import { ImBin } from "react-icons/im";
 import ConfirmationModal from "@/app/(ui)/components/Common/ConfirmationModal";
 import LoadingSpinner from "@/app/(ui)/components/Common/LoadingSpinner";
+import AddEditTestModal from "@/app/(ui)/components/Tests/AddEditTestModal";
 
 // Use the correct Test type
 type Test = Database["public"]["Tables"]["test_types"]["Row"];
@@ -200,19 +201,12 @@ export default function AdminTestsPage() {
           )}
         </div>
       </div>
-      {/* Add/Edit Test Modal (stub) */}
-      {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full">
-            <div className="font-semibold text-lg mb-4">{editTest ? "Edit Test" : "Add Test"}</div>
-            <div className="mb-4 text-gray-500 text-sm">(Test form UI goes here)</div>
-            <div className="flex justify-end gap-2">
-              <button className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700" onClick={() => setShowModal(false)}>Cancel</button>
-              <button className="px-4 py-2 rounded-lg bg-blue-600 text-white">{editTest ? "Update" : "Add"}</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <AddEditTestModal
+        open={showModal}
+        test={editTest}
+        onSaved={fetchTests}
+        close={() => setShowModal(false)}
+      />
       <ConfirmationModal
         open={openConfirmDeleteDialog}
         processing={isLoading}

--- a/src/app/(ui)/components/Tests/AddEditTestModal.tsx
+++ b/src/app/(ui)/components/Tests/AddEditTestModal.tsx
@@ -1,0 +1,135 @@
+"use client";
+import { FC, useEffect, useRef, useState } from "react";
+import { Modal } from "@/stories/Modal/Modal";
+import { Button } from "@/stories/Button/Button";
+import { LoadingButton } from "@/stories/Loading-Button/LoadingButton";
+import { successToast, errorToast } from "@/hooks/useCustomToast";
+import { Database } from "@/types/supabase";
+
+type Test = Database["public"]["Tables"]["test_types"]["Row"];
+
+interface AddEditTestModalProps {
+  open: boolean;
+  close: () => void;
+  onSaved: () => void;
+  test?: Test | null;
+}
+
+const AddEditTestModal: FC<AddEditTestModalProps> = ({
+  open,
+  close,
+  onSaved,
+  test,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [form, setForm] = useState({ name: "", description: "" });
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setForm({
+        name: test?.name || "",
+        description: test?.description || "",
+      });
+      setError(null);
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [open, test]);
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      setError("Name is required");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const res = await fetch("/api/admin/tests", {
+        method: test ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...form, id: test?.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to save test");
+      }
+      successToast(`Test ${test ? "updated" : "created"} successfully`);
+      onSaved();
+      close();
+    } catch (err) {
+      console.error(err);
+      errorToast(err instanceof Error ? err.message : "Failed to save test");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={test ? "Edit Test" : "Add Test"}
+      open={open}
+      close={close}
+      staticModal
+      panelClassName="!max-w-md"
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSave();
+        }}
+      >
+        {error && (
+          <div className="mb-4 p-2 bg-red-50 text-red-600 rounded">{error}</div>
+        )}
+        <div className="mb-4">
+          <label className="text-colorBlack font-medium mb-1 pl-0.5">Name</label>
+          <input
+            ref={inputRef}
+            type="text"
+            className="form-input"
+            value={form.name}
+            onChange={(e) => {
+              setForm({ ...form, name: e.target.value });
+              setError(null);
+            }}
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="text-colorBlack font-medium mb-1 pl-0.5">Description</label>
+          <textarea
+            className="form-input !h-28 resize-none"
+            value={form.description}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+          />
+        </div>
+        <div className="flex justify-end space-x-4 pt-4">
+          {isSaving ? (
+            <LoadingButton
+              className="!min-w-fit"
+              label={test ? "Updating..." : "Adding..."}
+            />
+          ) : (
+            <>
+              <Button
+                variant="white"
+                label="Cancel"
+                className="!min-w-fit"
+                type="button"
+                onClick={close}
+              />
+              <Button
+                className="!min-w-fit"
+                label={test ? "Update" : "Add"}
+                type="submit"
+              />
+            </>
+          )}
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default AddEditTestModal;


### PR DESCRIPTION
## Summary
- add AddEditTestModal for lab admin to create or edit test types
- integrate new modal into admin tests page

## Testing
- `npm test` *(fails: EHOSTUNREACH registry.npmjs.org)*