### PR TITLE
Fix user filtering and add test assignment modal

### DIFF
--- a/src/app/(ui)/(pages)/admin-dashboard/users/page.tsx
+++ b/src/app/(ui)/(pages)/admin-dashboard/users/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/stories/Button/Button";
 import { Card } from "@/stories/Card/Card";
 import ConfirmationModal from "@/app/(ui)/components/Common/ConfirmationModal";
 import LoadingSpinner from "@/app/(ui)/components/Common/LoadingSpinner";
+import AssignTestModal from "@/app/(ui)/components/Users/AssignTestModal";
 
 // Use the correct User type
 type User = Database["public"]["Tables"]["users"]["Row"] & {
@@ -56,8 +57,8 @@ export default function AdminUsersPage() {
 
   const filteredUsers = users.filter(
     (u) =>
-      u.full_name.toLowerCase().includes(search.toLowerCase()) ||
-      u.email.toLowerCase().includes(search.toLowerCase())
+      (u.full_name?.toLowerCase() || "").includes(search.toLowerCase()) ||
+      (u.email?.toLowerCase() || "").includes(search.toLowerCase())
   );
 
   const handleDeleteClick = (testId: string) => {
@@ -314,32 +315,15 @@ export default function AdminUsersPage() {
                 </table>
               </div>
             </div>
-            {/* Assign Test Modal (stub) */}
-            {showAssignModal && (
-              <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-                <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full">
-                  <div className="font-semibold text-lg mb-4">Assign Test</div>
-                  <div className="mb-4 text-gray-500 text-sm">
-                    (Test assignment UI goes here)
-                  </div>
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      label="Cancel"
-                      className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700"
-                      onClick={() => setShowAssignModal(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      label="Assign"
-                      className="px-4 py-2 rounded-lg bg-blue-600 text-white"
-                    >
-                      Assign
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
+            <AssignTestModal
+              open={showAssignModal}
+              close={() => setShowAssignModal(false)}
+              userId={selectedUser.id}
+              assignedTestIds={
+                selectedUser.assigned_tests?.map((t) => t.id) || []
+              }
+              onAssigned={fetchUsers}
+            />
             <ConfirmationModal
               open={openConfirmDeleteDialog}
               processing={isLoading}

--- a/src/app/(ui)/components/Dashboard/DashboardLayout.tsx
+++ b/src/app/(ui)/components/Dashboard/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-"use-client";
+"use client";
 import React, { useEffect, useState } from "react";
 import ProfileHeader from "./ProfileHeader";
 import { useMediaQuery } from "react-responsive";

--- a/src/app/(ui)/components/Users/AssignTestModal.tsx
+++ b/src/app/(ui)/components/Users/AssignTestModal.tsx
@@ -1,0 +1,104 @@
+"use client";
+import { FC, useEffect, useState } from "react";
+import { Modal } from "@/stories/Modal/Modal";
+import { Button } from "@/stories/Button/Button";
+import { LoadingButton } from "@/stories/Loading-Button/LoadingButton";
+import { successToast, errorToast } from "@/hooks/useCustomToast";
+import { MultiSelect } from "react-multi-select-component";
+import { Database } from "@/types/supabase";
+
+interface AssignTestModalProps {
+  open: boolean;
+  close: () => void;
+  userId: string;
+  assignedTestIds: string[];
+  onAssigned: () => void;
+}
+
+type Test = Database["public"]["Tables"]["test_types"]["Row"];
+
+const AssignTestModal: FC<AssignTestModalProps> = ({
+  open,
+  close,
+  userId,
+  assignedTestIds,
+  onAssigned,
+}) => {
+  const [tests, setTests] = useState<Test[]>([]);
+  const [selected, setSelected] = useState<{ label: string; value: string }[]>([]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const fetchTests = async () => {
+      const res = await fetch("/api/admin/tests");
+      const data = await res.json();
+      if (res.ok) {
+        const list = data.tests || data;
+        setTests(list);
+        setSelected(
+          list
+            .filter((t: Test) => assignedTestIds.includes(t.id))
+            .map((t: Test) => ({ label: t.name, value: t.id }))
+        );
+      } else {
+        errorToast(data.error || "Failed to load tests");
+      }
+    };
+    fetchTests();
+  }, [open, assignedTestIds]);
+
+  const handleAssign = async () => {
+    setIsSaving(true);
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, testIds: selected.map((s) => s.value) }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to assign tests");
+      successToast("Tests assigned successfully");
+      onAssigned();
+      close();
+    } catch (err: any) {
+      errorToast(err.message || "Failed to assign tests");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="Assign Tests"
+      open={open}
+      close={close}
+      staticModal
+      panelClassName="!max-w-md"
+    >
+      <div className="mb-4">
+        <label className="mb-2 block">Select Tests</label>
+        <MultiSelect
+          className="z-2 w-full mt-1"
+          options={tests.map((t) => ({ label: t.name, value: t.id }))}
+          value={selected}
+          onChange={setSelected}
+          labelledBy="Select Test(s)"
+          overrideStrings={{ selectSomeItems: "Select Test(s)", search: "Search Test(s)" }}
+        />
+      </div>
+      <div className="flex justify-end space-x-4 pt-4">
+        {isSaving ? (
+          <LoadingButton label="Saving..." className="!min-w-fit" />
+        ) : (
+          <>
+            <Button variant="white" label="Cancel" className="!min-w-fit" onClick={close} />
+            <Button label="Assign" className="!min-w-fit" onClick={handleAssign} />
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default AssignTestModal;


### PR DESCRIPTION
## Summary
- make DashboardLayout a client component
- add modal to assign tests to a user
- integrate AssignTestModal into users page
- guard against null names/emails when filtering users

## Testing
- `npm test` *(fails: npx jest could not download packages)*
- `npm run lint` *(fails: next not found)*